### PR TITLE
DOC: Fix some typos and improve style in hackathon project template

### DIFF
--- a/.github/ISSUE_TEMPLATE/hackathon-project-template.md
+++ b/.github/ISSUE_TEMPLATE/hackathon-project-template.md
@@ -22,7 +22,7 @@ Make sure you at least provide the information for the `{REQUIRED}` in the list 
 -   [ ] Project description () {REQUIRED}
 -   [ ] URL to project repository or documents {REQUIRED}
 -   [ ] Goals: set up 2 `good first issues` issues {REQUIRED}
--   [ ] Coding and GIT skills required (if applicable) {REQUIRED}
+-   [ ] Coding and Git skills required (if applicable) {REQUIRED}
 -   [ ] Skills you are particularly looking for {REQUIRED}
 -   [ ] Project leaders names {REQUIRED}
 -   [ ] Project leaders time zones
@@ -75,7 +75,7 @@ If your project involves any code you will want to set up a GitHub or GitLab rep
 
 If your project does not involve any coding, simply add a link to the relevant documents (google docs or on the open science framework) you will be working on.
 
-[YourRepo](_insert_URL_here) with a [REAME.md](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/write-a-great-project-readme/) containing:
+[YourRepo](_insert_URL_here) with a [README.md](https://mozilla.github.io/open-leadership-training-series/articles/opening-your-project/write-a-great-project-readme/) containing:
 -   project idea and context;
 -   installation guidelines if applicable;  
 -   links to further reading/tutorials;   
@@ -98,7 +98,7 @@ If you have set up a repository for your code, we will ask you to open at least 
 Some examples:
 -   implement a new feature for a package
 -   create a tutorial for a package
--   make a python version of your matlab based toolbox
+-   make a Python version of your Matlab based toolbox
 -   come up with a prototype of a standardized consent form that can be used by different labs
 -   create a fantastic list of neuroscience resources that will help generations of young researchers to come
 
@@ -106,7 +106,7 @@ Some examples:
 
 What different types of people could contribute?
 
-It is not all about coding. Are you interested in collaborating with someone with a good flair for good visualization? Someone with more experience who can makes a good user interface? Someone who knows how to develop good, tidy and clear documentation ?
+It is not all about coding. Are you interested in collaborating with someone with a good flair for good visualization? Someone with more experience who can make a good user interface? Someone who knows how to develop good, tidy and clear documentation ?
 
 ### Participant capacity
 
@@ -128,11 +128,11 @@ or use the table below
 
 | language          | level of expertise required   |
 |-------------------|-------------------------------|
-| python            | beginner / confirmed / expert |
-| javascript        | beginner / confirmed / expert |
+| Python            | beginner / confirmed / expert |
+| JavaScript        | beginner / confirmed / expert |
 | C++               | beginner / confirmed / expert |
-| java              | beginner / confirmed / expert |
-| unix command line | beginner / confirmed / expert |
+| Java              | beginner / confirmed / expert |
+| Unix command line | beginner / confirmed / expert |
 | other             | beginner / confirmed / expert |
 
 ### software specific sills
@@ -170,14 +170,14 @@ or use one of the tables below
 
 
 
-### GIT / GITHUB skills required
+### Git skills required
 
 | level   | description                                                                       |
 |---------|-----------------------------------------------------------------------------------|
-| GIT - 0 | no prior git knowledge                                                            |
-| GIT - 1 | can commit and push to a repository                                               |
-| GIT - 2 | comfortable working with branches and can do a pull request on another repository |
-| GIT - 3 | can work with continuous integration                                              |
+| Git - 0 | no prior Git knowledge                                                            |
+| Git - 1 | can commit and push to a repository                                               |
+| Git - 2 | comfortable working with branches and can do a pull request on another repository |
+| Git - 3 | can work with continuous integration                                              |
 
 ## Communication
 
@@ -191,18 +191,18 @@ If you already have a [slack]() workspace or are using [gitter]() or [discord]()
 
 ### Video calls
 
-To facilitate coordination we suggest you set up a [jitsi room](https://meet.jit.si/) or use zoom / [a permanent skype group](https://support.skype.com/en/faq/FA34799/how-do-i-create-a-group-chat-in-skype-on-desktop) / google hangout or some similar service so you can interact live with all project members wherever they are.
+To facilitate coordination we suggest you set up a [jitsi room](https://meet.jit.si/) or use zoom / [a permanent skype group](https://support.skype.com/en/faq/FA34799/how-do-i-create-a-group-chat-in-skype-on-desktop) / google hangouts or some similar service so you can interact live with all project members wherever they are.
 
 ### Suggested meeting time
 We recommend you have at least daily video meetings with your team members to organize things and keep track of progress.
 
-Try to suggest a time when meetings will happen. Of course this can then be changed and adapted if it turns out that most of the people who come to help you live on a completely different time zone from yours.
+Try to suggest a time when meetings will happen. Of course this can then be changed and adapted if it turns out that most of the people who come to help you live in a completely different time zone from yours.
 
 ### Code template to add
 
 If you want to help us list your project on the hackathon website, you can paste your `PROJECT TITLE` and `PROJECT DESCRIPTION` and the `ISSUE_NUMBER`of your project in the snippet of code below. You can also provide an image for your project.
 
-If you want you can then open a pull-request to add this code in the `_config.yml` file (section: `# Hackathon About Block` ; line 262). If you no idea how to do this, don't worry: we are here to help. If you want to add an image to illustrate your project it should go in the `img/hackathon` folder.
+If you want you can then open a pull-request to add this code in the [`_config.yml`](https://github.com/ohbm/hackathon2020/blob/master/_config.yml) file (section: `# Hackathon About Block`). If you no idea how to do this, don't worry: we are here to help. If you want to add an image to illustrate your project it should go in the [`img/hackathon`](https://github.com/ohbm/hackathon2020/tree/master/img/hackathon) folder.
 
 ```
 - {title: "PROJECT TITLE", image: "IMAGE_FILENAME", details: "PROJECT DESCRIPTION <br> More information here: <a href=https://github.com/ohbm/hackathon2020/issues/INSERT_ISSUE_NUMBER_HERE</a>"}


### PR DESCRIPTION
Fix some typos and improve style in hackathon project template, e.g.:
- Change `REAME` to `README`.
- Change the case of some languages/tools to honor their case and use it
  consistently.
- Remove `GITHUB` since three out of the four skills are Git-related and CI can
  also be done in GitLab (or the code host platform of choice).
- Link the specific documents or folders in the repository and remove the line
  number since it can get out of sync easily.