### PR TITLE
First copy of info for helpdesk role

### DIFF
--- a/.github/ISSUE_TEMPLATE/handbooks/helpdesk_role.md
+++ b/.github/ISSUE_TEMPLATE/handbooks/helpdesk_role.md
@@ -1,0 +1,34 @@
+# Helpdesh member: role description
+
+The [OHBM Brainhack 2020](https://ohbm.github.io/hackathon2020/) will gather researchers throughout the world for an online hackathon June 16-18, organized around 3 hubs: 'Asia and Pacific', 'Africa, Middle East and Europe' and the 'Americas'.
+
+---
+
+*Signup for the Brainhack helpdesk and answer attendees’ technical questions! As a member of the helpdesk you will monitor the helpdesk channel and answer any questions related to your expertise.*
+
+---
+
+**Members of the helpdesk** provide essential technical support for attendees throughout the event. 
+
+#### Description
+
+During the Brainhack, the 'helpdesk' team will provide 1-1 technical support to Brainhack attendees. We want to have chat channels that attendees can turn to when they have a problem (like a code issue when working on a project or problem setting up some software for a traintrack workshop). We need people to help us reply to questions and troubleshoot issues attendees might have.
+
+#### Profile
+
+A helpdesk member is a member of the open science neuroimaging community who:
+ - has some technical expertise
+ - feels comfortable listening to attendees' questions, direct them to existing resources and share answers as needed
+ 
+
+#### Expectations
+1. Help develop and maintain a welcoming environment at the OHBM Brainhack
+2. 
+3. 
+
+#### Estimated time
+
+
+#### Join the team!
+Thank you so much for willing to help. In order to sign up as a Brainhack buddy, please fill in this form (TODO!). 
+

--- a/.github/ISSUE_TEMPLATE/handbooks/helpdesk_role.md
+++ b/.github/ISSUE_TEMPLATE/handbooks/helpdesk_role.md
@@ -1,34 +1,40 @@
 # Helpdesh member: role description
 
-The [OHBM Brainhack 2020](https://ohbm.github.io/hackathon2020/) will gather researchers throughout the world for an online hackathon June 16-18, organized around 3 hubs: 'Asia and Pacific', 'Africa, Middle East and Europe' and the 'Americas'.
+The [OHBM Brainhack 2020](https://ohbm.github.io/hackathon2020/) will gather researchers throughout
+the world for an online hackathon June 16-18, organized around 3 hubs: 'Asia and Pacific', 'Africa,
+ Middle East and Europe' and the 'Americas'.
 
 ---
 
-*Signup for the Brainhack helpdesk and answer attendees’ technical questions! As a member of the helpdesk you will monitor the helpdesk channel and answer any questions related to your expertise.*
+*Signup for the Brainhack helpdesk and answer attendees’ technical questions! As a member of the
+helpdesk you will monitor the helpdesk channel and answer any questions related to your expertise.*
 
 ---
 
-**Members of the helpdesk** provide essential technical support for attendees throughout the event. 
+**Members of the helpdesk** provide essential technical support for attendees throughout the event.
 
 #### Description
 
-During the Brainhack, the 'helpdesk' team will provide 1-1 technical support to Brainhack attendees. We want to have chat channels that attendees can turn to when they have a problem (like a code issue when working on a project or problem setting up some software for a traintrack workshop). We need people to help us reply to questions and troubleshoot issues attendees might have.
+During the Brainhack, the 'helpdesk' team will provide 1-1 technical support to Brainhack attendees.
+We want to have chat channels that attendees can turn to when they have a problem (like a code issue
+when working on a project or problem setting up some software for a traintrack workshop).
+We need people to help us reply to questions and troubleshoot issues attendees might have.
 
 #### Profile
 
 A helpdesk member is a member of the open science neuroimaging community who:
  - has some technical expertise
  - feels comfortable listening to attendees' questions, direct them to existing resources and share answers as needed
- 
 
 #### Expectations
+
 1. Help develop and maintain a welcoming environment at the OHBM Brainhack
-2. 
-3. 
+2.
+3.
 
 #### Estimated time
 
 
 #### Join the team!
-Thank you so much for willing to help. In order to sign up as a Brainhack buddy, please fill in this form (TODO!). 
 
+Thank you so much for willing to help. In order to sign up as a Brainhack buddy, please fill in this form (TODO!).

--- a/.github/ISSUE_TEMPLATE/handbooks/helpdesk_role.md
+++ b/.github/ISSUE_TEMPLATE/handbooks/helpdesk_role.md
@@ -23,14 +23,15 @@ We need people to help us reply to questions and troubleshoot issues attendees m
 #### Profile
 
 A helpdesk member is a member of the open science neuroimaging community who:
- - has some technical expertise
- - feels comfortable listening to attendees' questions, direct them to existing resources and share answers as needed
+-   has some technical expertise
+-   feels comfortable listening to attendees' questions, direct them to existing resources and share
+answers as needed
 
 #### Expectations
 
-1. Help develop and maintain a welcoming environment at the OHBM Brainhack
-2.
-3.
+1.  Help develop and maintain a welcoming environment at the OHBM Brainhack
+2.  Help attendees to set up anything needed before a given traintrack session
+3.  Help attendees troubleshoot issues that might prevent their hacking project from making progress.
 
 #### Estimated time
 


### PR DESCRIPTION
Similar to https://github.com/ohbm/hackathon2020/pull/103, this PR creates a document to describe the hackathon helpdesk member role. We will link to this doc from the website and emails we send to invite people to join.