### PR TITLE
fix: minor typo on the Schedule page

### DIFF
--- a/_data/sessions.yml
+++ b/_data/sessions.yml
@@ -97,7 +97,7 @@
   title: "Project Q&A"
   place: "Crowdcast"
   description: "All the attendees can go and meet the project leaders in their video breakout room
-  to talk with thelm about the project."
+  to talk with them about the project."
 -
   id: 104
   type: hacktrack


### PR DESCRIPTION
fixes a minor typo on the Schedule Page

![image](https://user-images.githubusercontent.com/36276423/84703682-4b25ed80-af76-11ea-9bdf-00f43994fe1f.png)
