### PR TITLE
Fix "Join Projects" link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,7 +70,7 @@ typeoutTextValues: '"June 16-18th, 2020", "Worldwide!", ""'
 typeoutFallback: ""
 heroButtons:
    - {link: "http://www.humanbrainmapping.org/HackathonReg/", text: "Register NOW!"}
-   - {link: "https://ohbm.github.io/hackathon2020/hackathon/", text: "Join a project"}
+   - {link: "https://ohbm.github.io/hackathon2020/hacktrack/", text: "Join a project"}
    - {link: "https://neurostars.org/t/ohbm-brainhack-2020/6192/8?u=remi-gau", text: "Want to help?"}
 
 


### PR DESCRIPTION
Link is broken, goes to https://ohbm.github.io/hackathon2020/hackathon/, but should go to https://ohbm.github.io/hackathon2020/hacktrack/